### PR TITLE
right bump removed

### DIFF
--- a/lib/src/pizzule_path.dart
+++ b/lib/src/pizzule_path.dart
@@ -58,15 +58,6 @@ Path getPiecePathCustom(
   path.lineTo(offsetX + sizePart, offsetY);
 
   // right bump
-  path.lineTo(offsetX + sizePart, offsetY + sizePart / 3);
-
-  path.cubicTo(
-      offsetX + sizePart + bumpSize,
-      offsetY + sizePart / 6,
-      offsetX + sizePart + bumpSize,
-      offsetY + sizePart / 6 * 5,
-      offsetX + sizePart,
-      offsetY + sizePart / 3 * 2);
 
   path.lineTo(offsetX + sizePart, offsetY + sizePart);
 


### PR DESCRIPTION
Before: there was a path to draw a right bump, but it wasn't displayed in a filled fragment.

After: the right bump was removed.